### PR TITLE
Fix program throwing errors after RACOON Mario collided with Super Mushroom or Super Leaf

### DIFF
--- a/NES-Super-Mario-Bros-3/SuperLeaf.cpp
+++ b/NES-Super-Mario-Bros-3/SuperLeaf.cpp
@@ -89,7 +89,7 @@ void CSuperLeaf::OnCollisionWith(LPCOLLISIONEVENT e)
 	if (CMario* mario = dynamic_cast<CMario*>(e->obj))
 	{
 		mario->InsertScoreObject(x, y - 16, 1000);
-		LaunchEffect(e);
+		if (mario->GetLife() != MARIO_LEVEL_RACOON) LaunchEffect(e);
 		SetState(STATE_DIE);
 	}
 }

--- a/NES-Super-Mario-Bros-3/SuperMushroom.cpp
+++ b/NES-Super-Mario-Bros-3/SuperMushroom.cpp
@@ -132,7 +132,7 @@ void CSuperMushroom::OnCollisionWithMario(LPCOLLISIONEVENT e)
 	if (CMario* mario = dynamic_cast<CMario*>(e->obj))
 	{
 		mario->InsertScoreObject(x, y - 16, 1000);
-		CHelpfulObject::LaunchEffect(e);
+		if (mario->GetLife() != MARIO_LEVEL_RACOON) CHelpfulObject::LaunchEffect(e);
 		SetState(STATE_DIE);
 	}
 }


### PR DESCRIPTION
With a condition of Mario's life not being a racoon for SuperLeaf and SuperMushroom, the program no longer throws errors. There will be no changes to Mario's appearance.